### PR TITLE
unify workspace resolver to 3, and unify dependencies across workspace with autoinherit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["zexcavator-cli", "zexcavator-lib", "zexcavator-tui"]
+resolver = "3"
 
 [workspace.dependencies.zingolib]
 git = "https://github.com/zingolabs/zingolib.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,35 @@
 members = ["zexcavator-cli", "zexcavator-lib", "zexcavator-tui"]
 resolver = "3"
 
+[workspace.dependencies]
+abscissa_core = "0.8.2"
+bc-envelope = "0.24.0"
+bip0039 = "0.12.0"
+bridgetree = "0.6.0"
+byteorder = "1.5.0"
+clap = "4"
+hex = "0.4.3"
+http = "1.3.1"
+jubjub = "0.10.0"
+once_cell = "1.2"
+orchard = "0.10.0"
+prost = "0.13.4"
+rusqlite = "0.32.1"
+rustls = "0.23.25"
+sapling = { version = "0.3", default-features = false }
+secp256k1 = "0.27.0"
+serde = "1"
+thiserror = "1"
+tokio = "1.44.2"
+tui-realm-stdlib = "2"
+tuirealm = "2"
+zcash_client_backend = "0.15.0"
+zcash_encoding = "0.2.2"
+zcash_keys = "0.5.0"
+zcash_primitives = "0.20.0"
+zewif-zwl = { git = "https://github.com/zingolabs/zewif-zwl", branch = "zewif-migration" }
+zexcavator-lib = { path = "zexcavator-lib" }
+
 [workspace.dependencies.zingolib]
 git = "https://github.com/zingolabs/zingolib.git"
 branch = "dev"

--- a/zexcavator-cli/Cargo.toml
+++ b/zexcavator-cli/Cargo.toml
@@ -4,20 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-zexcavator-lib = { path = "../zexcavator-lib" }
-clap = "4"
-serde = { version = "1", features = ["serde_derive"] }
-thiserror = "1"
-bc-envelope = "0.24.0"
-tokio = "1.44.2"
-http = "1.3.1"
+zexcavator-lib = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true, features = ["serde_derive"] }
+thiserror = { workspace = true }
+bc-envelope = { workspace = true }
+tokio = { workspace = true }
+http = { workspace = true }
 zingolib = { workspace = true }
-rustls = "0.23.25"
-zewif-zwl = { git = "https://github.com/zingolabs/zewif-zwl", branch = "zewif-migration" }
-
-[dependencies.abscissa_core]
-version = "0.8.2"
+rustls = { workspace = true }
+zewif-zwl = { workspace = true }
+abscissa_core= { workspace = true }
 
 [dev-dependencies]
-abscissa_core = { version = "0.8.1", features = ["testing"] }
-once_cell = "1.2"
+abscissa_core = { workspace = true, features = ["testing"] }
+once_cell = { workspace = true }

--- a/zexcavator-lib/Cargo.toml
+++ b/zexcavator-lib/Cargo.toml
@@ -4,26 +4,19 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-byteorder = "1.5.0"
-zcash_primitives = { version = "0.20.0", features = ["transparent-inputs"] }
-zcash_encoding = "0.2.2"
-zcash_keys = { version = "0.5.0", features = [
-    "transparent-inputs",
-    "sapling",
-    "orchard",
-] }
-zcash_client_backend = { version = "0.15.0", features = [
-    "transparent-inputs",
-    "orchard",
-] }
-orchard = "0.10.0"
+byteorder = { workspace = true }
+zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
+zcash_encoding = { workspace = true }
+zcash_keys = { workspace = true, features = ["transparent-inputs", "sapling", "orchard"] }
+zcash_client_backend = { workspace = true, features = ["transparent-inputs", "orchard"] }
+orchard = { workspace = true }
 sapling = { package = "sapling-crypto", version = "0.3", default-features = false }
-secp256k1 = { version = "0.27.0" }
-bip0039 = "0.12.0"
-hex = "0.4.3"
-jubjub = "0.10.0"
-rusqlite = "0.32.1"
-bridgetree = "0.6.0"
-prost = "0.13.4"
+secp256k1 = { workspace = true }
+bip0039 = { workspace = true }
+hex = { workspace = true }
+jubjub = { workspace = true }
+rusqlite = { workspace = true }
+bridgetree = { workspace = true }
+prost = { workspace = true }
 
 # zingolib = { workspace = true }

--- a/zexcavator-tui/Cargo.toml
+++ b/zexcavator-tui/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-tuirealm = "2"
-tui-realm-stdlib = "2"
+tuirealm = { workspace = true }
+tui-realm-stdlib = { workspace = true }


### PR DESCRIPTION
Make the resolver be "3".

Track and unify all dependency version information in the workspace manifest with:

`cargo autoinherit`